### PR TITLE
Material UI components to MDX content

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -32,5 +32,6 @@ module.exports = {
         extensions: [`.mdx`, `.md`],
       },
     },
+    `gatsby-plugin-mui-mdx-provider`,
   ],
 };

--- a/plugins/gatsby-plugin-mui-mdx-provider/MuiComponentsProvider.tsx
+++ b/plugins/gatsby-plugin-mui-mdx-provider/MuiComponentsProvider.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
 import { MDXProvider } from '@mdx-js/react';
 import { Typography, Link, Divider, List, ListItem, Table, TableRow, TableCell } from '@material-ui/core';
-import { StaticImage } from 'gatsby-plugin-image';
 
 const components = {
-  p: (props) => <Typography {...props} />,
-  h1: (props) => <Typography varianth='h1' {...props} />,
-  h2: (props) => <Typography varianth='h2' {...props} />,
-  h3: (props) => <Typography varianth='h3' {...props} />,
-  h4: (props) => <Typography varianth='h4' {...props} />,
-  h5: (props) => <Typography varianth='h5' {...props} />,
-  h6: (props) => <Typography varianth='h6' {...props} />,
+  p: (props) => <Typography gutterBottom align='justify' {...props} />,
+  h1: (props) => <Typography variant='h1' gutterBottom {...props} />,
+  h2: (props) => <Typography variant='h2' gutterBottom {...props} />,
+  h3: (props) => <Typography variant='h3' gutterBottom {...props} />,
+  h4: (props) => <Typography variant='h4' gutterBottom {...props} />,
+  h5: (props) => <Typography variant='h5' gutterBottom {...props} />,
+  h6: (props) => <Typography variant='h6' gutterBottom {...props} />,
   thematicBreak: (props) => <Divider {...props} />,
   blockquote: (props) => <Typography variant='body2' component='blockquote' {...props} />,
   ul: (props) => <List {...props} />,

--- a/plugins/gatsby-plugin-mui-mdx-provider/MuiComponentsProvider.tsx
+++ b/plugins/gatsby-plugin-mui-mdx-provider/MuiComponentsProvider.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { MDXProvider } from '@mdx-js/react';
+import { Typography, Link } from '@material-ui/core';
+
+const muiParagraph = (props) => <Typography {...props} />;
+const muiH1 = (props) => <Typography varianth='h1' {...props} />;
+const muiH2 = (props) => <Typography varianth='h2' {...props} />;
+const muiH3 = (props) => <Typography varianth='h3' {...props} />;
+const muiH4 = (props) => <Typography varianth='h4' {...props} />;
+const muiH5 = (props) => <Typography varianth='h5' {...props} />;
+const muiH6 = (props) => <Typography varianth='h6' {...props} />;
+const muiLink = (props) => <Link {...props} />;
+
+const components = {
+  p: muiParagraph,
+  h1: muiH1,
+  h2: muiH2,
+  h3: muiH3,
+  h4: muiH4,
+  h5: muiH5,
+  h6: muiH6,
+  a: muiLink,
+};
+
+const MuiComponentProvider = ({ children }) => {
+  return <MDXProvider components={components}>{children}</MDXProvider>;
+};
+
+export default MuiComponentProvider;

--- a/plugins/gatsby-plugin-mui-mdx-provider/MuiComponentsProvider.tsx
+++ b/plugins/gatsby-plugin-mui-mdx-provider/MuiComponentsProvider.tsx
@@ -1,25 +1,21 @@
 import React from 'react';
 import { MDXProvider } from '@mdx-js/react';
-import { Typography, Link } from '@material-ui/core';
-
-const muiParagraph = (props) => <Typography {...props} />;
-const muiH1 = (props) => <Typography varianth='h1' {...props} />;
-const muiH2 = (props) => <Typography varianth='h2' {...props} />;
-const muiH3 = (props) => <Typography varianth='h3' {...props} />;
-const muiH4 = (props) => <Typography varianth='h4' {...props} />;
-const muiH5 = (props) => <Typography varianth='h5' {...props} />;
-const muiH6 = (props) => <Typography varianth='h6' {...props} />;
-const muiLink = (props) => <Link {...props} />;
+import { Typography, Link, Divider, List, ListItem } from '@material-ui/core';
 
 const components = {
-  p: muiParagraph,
-  h1: muiH1,
-  h2: muiH2,
-  h3: muiH3,
-  h4: muiH4,
-  h5: muiH5,
-  h6: muiH6,
-  a: muiLink,
+  p: (props) => <Typography {...props} />,
+  h1: (props) => <Typography varianth='h1' {...props} />,
+  h2: (props) => <Typography varianth='h2' {...props} />,
+  h3: (props) => <Typography varianth='h3' {...props} />,
+  h4: (props) => <Typography varianth='h4' {...props} />,
+  h5: (props) => <Typography varianth='h5' {...props} />,
+  h6: (props) => <Typography varianth='h6' {...props} />,
+  thematicBreak: (props) => <Divider {...props} />,
+  blockquote: (props) => <Typography variant='body2' component='blockquote' {...props} />,
+  a: (props) => <Link {...props} />,
+  ul: (props) => <List {...props} />,
+  ol: (props) => <List component='ol' {...props} />,
+  li: (props) => <ListItem {...props} />,
 };
 
 const MuiComponentProvider = ({ children }) => {

--- a/plugins/gatsby-plugin-mui-mdx-provider/MuiComponentsProvider.tsx
+++ b/plugins/gatsby-plugin-mui-mdx-provider/MuiComponentsProvider.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { MDXProvider } from '@mdx-js/react';
-import { Typography, Link, Divider, List, ListItem } from '@material-ui/core';
+import { Typography, Link, Divider, List, ListItem, Table, TableRow, TableCell } from '@material-ui/core';
+import { StaticImage } from 'gatsby-plugin-image';
 
 const components = {
   p: (props) => <Typography {...props} />,
@@ -12,10 +13,21 @@ const components = {
   h6: (props) => <Typography varianth='h6' {...props} />,
   thematicBreak: (props) => <Divider {...props} />,
   blockquote: (props) => <Typography variant='body2' component='blockquote' {...props} />,
-  a: (props) => <Link {...props} />,
   ul: (props) => <List {...props} />,
   ol: (props) => <List component='ol' {...props} />,
   li: (props) => <ListItem {...props} />,
+  table: (props) => <Table {...props} />,
+  tr: (props) => <TableRow {...props} />,
+  th: (props) => <TableCell component='thead' {...props} />,
+  td: (props) => <TableCell {...props} />,
+  pre: (props) => <Typography component='pre' {...props} />,
+  code: (props) => <Typography component='code' {...props} />,
+  em: (props) => <Typography component='em' {...props} />,
+  strong: (props) => <Typography component='strong' {...props} />,
+  delete: (props) => <Typography component='del' {...props} />,
+  inlineCode: (props) => <Typography component='code' {...props} />,
+  hr: (props) => <Divider component='hr' {...props} />,
+  a: (props) => <Link {...props} />,
 };
 
 const MuiComponentProvider = ({ children }) => {

--- a/plugins/gatsby-plugin-mui-mdx-provider/gatsby-browser.js
+++ b/plugins/gatsby-plugin-mui-mdx-provider/gatsby-browser.js
@@ -1,0 +1,7 @@
+/* eslint-disable import/prefer-default-export, react/prop-types */
+import React from 'react';
+import MuiComponentProvider from './MuiComponentsProvider';
+
+export const wrapRootElement = ({ element }) => {
+  return <MuiComponentProvider>{element}</MuiComponentProvider>;
+};

--- a/plugins/gatsby-plugin-mui-mdx-provider/gatsby-ssr.js
+++ b/plugins/gatsby-plugin-mui-mdx-provider/gatsby-ssr.js
@@ -1,0 +1,7 @@
+/* eslint-disable import/prefer-default-export, react/prop-types */
+import React from 'react';
+import MuiComponentProvider from './MuiComponentsProvider';
+
+export const wrapRootElement = ({ element }) => {
+  return <MuiComponentProvider>{element}</MuiComponentProvider>;
+};

--- a/plugins/gatsby-plugin-mui-mdx-provider/package.json
+++ b/plugins/gatsby-plugin-mui-mdx-provider/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "gatsby-plugin-mui-mdx-provider"
+}

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,8 +1,8 @@
-import { createMuiTheme } from "@material-ui/core/styles";
+import { createMuiTheme } from '@material-ui/core/styles';
 
 const theme = createMuiTheme({
   palette: {
-    type: "dark",
+    type: 'dark',
   },
 });
 


### PR DESCRIPTION
Simple plugin that maps Material UI components to be used for the Markdown content. Probably needs some styling attention later but it should cover components listed in [gatsby-plugin-mdx](https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx/?=mdx#components)