### PR TITLE
Bumped node version for gh actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: "18"
 
       - name: Cache dependencies
         uses: actions/cache@v2

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\""
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
+    "test": ""
   },
   "dependencies": {
     "@emotion/react": "^11.9.0",


### PR DESCRIPTION
Node version bumped from 14 to 18 for gatsby v5